### PR TITLE
feat(combo): per-entry reasoning effort with legacy string[] compat

### DIFF
--- a/cli/src/cli/menus/combos.js
+++ b/cli/src/cli/menus/combos.js
@@ -7,13 +7,50 @@ const { showMenuWithBack } = require("../utils/menuHelper");
 
 /**
  * Format model to string (handle both string and object)
+ * Entry may be a legacy "provider/model" string or { model, reasoning }.
  */
-function formatModel(model) {
+const COMBO_REASONING_LEVELS = ["auto", "none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+function entryModelString(model) {
   if (typeof model === "string") return model;
   if (model && typeof model === "object") {
-    return model.id || model.name || `${model.provider}/${model.model}` || JSON.stringify(model);
+    if (typeof model.model === "string" && model.model.trim()) {
+      const m = model.model.trim();
+      if (typeof model.provider === "string" && model.provider.trim() && !m.includes("/")) {
+        return `${model.provider.trim()}/${m}`;
+      }
+      return m;
+    }
+    return model.id || model.name || "";
   }
-  return String(model);
+  return "";
+}
+
+function entryReasoningString(model) {
+  if (!model || typeof model !== "object") return "";
+  return model.reasoning || model.reasoning_effort || "";
+}
+
+function formatModel(model) {
+  const base = entryModelString(model) || String(model);
+  const reasoning = entryReasoningString(model);
+  return reasoning ? `${base} (${reasoning})` : base;
+}
+
+function toComboEntry(modelValue, reasoning) {
+  const base = entryModelString(modelValue) || String(modelValue || "");
+  if (!reasoning || reasoning === "auto") return base;
+  return { model: base, reasoning };
+}
+
+async function promptReasoningLevel(current = "auto") {
+  while (true) {
+    const input = await prompt(`Reasoning effort [${COMBO_REASONING_LEVELS.join("/")}] (Enter for "${current}"): `);
+    if (!input) return current;
+    const value = String(input).trim().toLowerCase();
+    if (COMBO_REASONING_LEVELS.includes(value)) return value;
+    showStatus(`Invalid effort "${input}" — use one of: ${COMBO_REASONING_LEVELS.join(", ")}`, "error");
+  }
 }
 
 /**
@@ -62,19 +99,21 @@ async function handleEditSingleCombo(combo) {
   
   console.log("\nCurrent models: " + (Array.isArray(combo.models) ? combo.models.map(formatModel).join(" → ") : ""));
   console.log("\nSelect models for this combo (add one by one):");
-  
+
   const models = [];
   let addMore = true;
-  
+
   while (addMore) {
-    const currentChain = models.length > 0 ? models.join(" → ") : "None";
+    const currentChain = models.length > 0 ? models.map(formatModel).join(" → ") : "None";
     const model = await selectModelFromList(`Add Model #${models.length + 1}`, `Chain: ${currentChain}`);
-    
+
     if (model) {
-      models.push(model);
-      console.log(`\n✓ Added: ${model}`);
-      console.log(`Current chain: ${models.join(" → ")}\n`);
-      
+      const reasoning = await promptReasoningLevel("auto");
+      const entry = toComboEntry(model, reasoning);
+      models.push(entry);
+      console.log(`\n✓ Added: ${formatModel(entry)}`);
+      console.log(`Current chain: ${models.map(formatModel).join(" → ")}\n`);
+
       const continueAdding = await confirm("Add another model?");
       addMore = continueAdding;
     } else {
@@ -178,11 +217,11 @@ async function showComboDetail(comboId) {
   console.log("│                                                          │");
   console.log("│  Model Chain:                                           │");
   
-  // Models is array of strings like ["ag/claude-sonnet-4-5", "kr/claude-sonnet-4.5"]
+  // Models may be legacy strings or { model, reasoning } entries
   const models = Array.isArray(combo.models) ? combo.models : [];
-  models.forEach((modelStr, index) => {
+  models.forEach((entry, index) => {
     const arrow = index < models.length - 1 ? " →" : "  ";
-    const displayText = `${index + 1}. ${modelStr}${arrow}`;
+    const displayText = `${index + 1}. ${formatModel(entry)}${arrow}`;
     const padding = Math.max(0, 54 - displayText.length);
     console.log(`│    ${displayText}${" ".repeat(padding)} │`);
   });
@@ -250,35 +289,35 @@ async function handleCreateCombo() {
     clearScreen();
     console.log(`Creating combo: ${name}`);
     console.log(`Selected models (${selectedModels.length}):`);
-    
+
     if (selectedModels.length > 0) {
       selectedModels.forEach((m, i) => {
-        console.log(`  ${i + 1}. ${m.provider}/${m.model}`);
+        console.log(`  ${i + 1}. ${formatModel(m)}`);
       });
     } else {
       console.log("  (none)");
     }
-    
+
     console.log();
     console.log("Available models:");
     availableModels.forEach((m, i) => {
-      console.log(`  ${i + 1}. ${m.provider}/${m.model}`);
+      console.log(`  ${i + 1}. ${entryModelString(m) || formatModel(m)}`);
     });
-    
+
     console.log();
     console.log("Actions:");
     console.log("  - Enter number to add model");
     console.log("  - Type 'done' to finish (min 2 models)");
     console.log("  - Type 'cancel' to abort");
-    
+
     const input = await prompt("\nAction: ");
-    
+
     if (input.toLowerCase() === "cancel") {
       showStatus("Cancelled", "warning");
       await pause();
       return;
     }
-    
+
     if (input.toLowerCase() === "done") {
       if (selectedModels.length < 2) {
         showStatus("Please select at least 2 models", "error");
@@ -287,15 +326,20 @@ async function handleCreateCombo() {
       }
       break;
     }
-    
+
     const num = parseInt(input, 10);
     if (isNaN(num) || num < 1 || num > availableModels.length) {
       showStatus("Invalid model number", "error");
       await pause();
       continue;
     }
-    
-    selectedModels.push(availableModels[num - 1]);
+
+    const picked = availableModels[num - 1];
+    const reasoning = await promptReasoningLevel("auto");
+    const entry = toComboEntry(picked, reasoning);
+    selectedModels.push(entry);
+    showStatus(`Added: ${formatModel(entry)}`, "success");
+    await pause();
   }
   
   // Create combo
@@ -365,7 +409,7 @@ async function editSingleCombo(combo) {
       console.log(`Selected models (${newModels.length}):`);
       
       if (newModels.length > 0) {
-        newModels.forEach((m, i) => console.log(`  ${i + 1}. ${m}`));
+        newModels.forEach((m, i) => console.log(`  ${i + 1}. ${formatModel(m)}`));
       } else {
         console.log("  (none)");
       }
@@ -389,8 +433,10 @@ async function editSingleCombo(combo) {
         break;
       }
       
-      newModels.push(model);
-      showStatus(`Added: ${model}`, "success");
+      const reasoning = await promptReasoningLevel("auto");
+      const entry = toComboEntry(model, reasoning);
+      newModels.push(entry);
+      showStatus(`Added: ${formatModel(entry)}`, "success");
       await pause();
     }
   }

--- a/open-sse/services/capacityAdapter.js
+++ b/open-sse/services/capacityAdapter.js
@@ -16,6 +16,7 @@
  * can actually satisfy it.
  */
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
+import { getComboEntryModel } from "./comboEntry.js";
 
 const CAPABILITY_KEYS = ["vision", "pdf", "audioInput", "videoInput"];
 const HARD_CAPS = new Set(CAPABILITY_KEYS);
@@ -82,7 +83,8 @@ export function getActiveAdapterStrategy(requiredCapabilities, settings) {
   return "fallback";
 }
 
-function modelSatisfies(modelStr, requiredHard) {
+function modelSatisfies(entry, requiredHard) {
+  const modelStr = getComboEntryModel(entry) || "";
   const slash = modelStr.indexOf("/");
   const provider = slash > 0 ? modelStr.slice(0, slash) : "";
   const model = slash > 0 ? modelStr.slice(slash + 1) : modelStr;
@@ -101,7 +103,8 @@ export function augmentModelsWithCapacityAdapter(models, requiredCapabilities, s
   if (hard.length === 0 || !Array.isArray(models) || models.length === 0) return models;
   if (models.some((m) => modelSatisfies(m, hard))) return models;
 
-  const pool = getCapacityAdapterModels(settings).filter((m) => !models.includes(m) && modelSatisfies(m, hard));
+  const seen = new Set(models.map((m) => getComboEntryModel(m)));
+  const pool = getCapacityAdapterModels(settings).filter((m) => !seen.has(m) && modelSatisfies(m, hard));
   if (pool.length === 0) return models;
   return [...pool, ...models];
 }

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -13,23 +13,19 @@ import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { bestScoreForProviderModel } from "./quotaPreflight.js";
 import { parseModel } from "./model.js";
 import { getNextFamilyFallback, isModelUnavailableError } from "./modelFamilyFallback.js";
+import { getComboEntryModel, applyComboEntryReasoning } from "./comboEntry.js";
+export { normalizeComboEntry, normalizeComboEntries, getComboEntryModel, getComboEntryReasoning, applyComboEntryReasoning } from "./comboEntry.js";
 
-// Quota-aware combo ordering (0.5.27).
-// Sort combo entries so the model with the highest remaining quota across
-// any of its provider's accounts tries first. Entries with no quota info
-// keep their declared position relative to each other (stable sort).
-// Returns a new array; never mutates input.
 function reorderByQuota(models) {
   if (!Array.isArray(models) || models.length < 2) return models;
-  const scored = models.map((modelStr, originalIndex) => {
+  const scored = models.map((entry, originalIndex) => {
+    const modelStr = getComboEntryModel(entry);
     const { provider, model } = parseModel(modelStr);
-    if (!provider || !model) return { modelStr, score: null, originalIndex };
-    return { modelStr, score: bestScoreForProviderModel(provider, model), originalIndex };
+    if (!provider || !model) return { entry, score: null, originalIndex };
+    return { entry, score: bestScoreForProviderModel(provider, model), originalIndex };
   });
   const hasAnyScore = scored.some(s => s.score !== null);
   if (!hasAnyScore) return models;
-  // Items with a score sort by score DESC; null-scored items keep relative order
-  // and sit AFTER scored items so we prefer known-good over unknown.
   scored.sort((a, b) => {
     if (a.score === null && b.score === null) return a.originalIndex - b.originalIndex;
     if (a.score === null) return 1;
@@ -37,7 +33,7 @@ function reorderByQuota(models) {
     if (b.score !== a.score) return b.score - a.score;
     return a.originalIndex - b.originalIndex;
   });
-  return scored.map(s => s.modelStr);
+  return scored.map(s => s.entry);
 }
 
 // Hard capabilities = input modalities. Missing one drops request data
@@ -273,9 +269,10 @@ export function reorderByCapabilities(models, required) {
   if (hard.length === 0) return models;
 
   const tierOf = (m) => {
-    const slash = typeof m === "string" ? m.indexOf("/") : -1;
-    const provider = slash > 0 ? m.slice(0, slash) : "";
-    const model = slash > 0 ? m.slice(slash + 1) : m;
+    const modelStr = getComboEntryModel(m);
+    const slash = typeof modelStr === "string" ? modelStr.indexOf("/") : -1;
+    const provider = slash > 0 ? modelStr.slice(0, slash) : "";
+    const model = slash > 0 ? modelStr.slice(slash + 1) : modelStr;
     const caps = getCapabilitiesForModel(provider, model);
     return hard.every((c) => caps[c] === true) ? 0 : 1;
   };
@@ -288,57 +285,45 @@ export function reorderByCapabilities(models, required) {
 }
 
 export async function handleComboChat({ body, models, handleSingleModel, log, comboName, comboStrategy, comboStickyLimit = 1, autoSwitch = true }) {
-  // Apply rotation strategy if enabled
   let rotatedModels = getRotatedModels(models, comboName, comboStrategy, comboStickyLimit);
 
-  // Capacity auto-switch: float models that satisfy required input modalities
-  // (vision/pdf) to the front so an image request doesn't get silently
-  // stripped at a text-only model.
   if (autoSwitch) {
     const required = detectRequiredCapabilities(body);
     if (required.size > 0) {
       const reordered = reorderByCapabilities(rotatedModels, required);
       if (reordered[0] !== rotatedModels[0]) {
-        log?.info?.("COMBO", `Capacity auto-switch: ${[...required].join(",")} → reordered to ${reordered[0]} first`);
+        log?.info?.("COMBO", `Capacity auto-switch: ${[...required].join(",")} → reordered to ${getComboEntryModel(reordered[0])} first`);
       }
       rotatedModels = reordered;
     }
   }
 
-  // Quota-aware ordering (0.5.27): float entries whose provider has the most
-  // remaining quota for that model to the front. Capability sort still wins
-  // when both apply because we run AFTER it — quota reorder only swaps within
-  // the capability-compatible group.
   if (autoSwitch) {
     const reorderedByQuota = reorderByQuota(rotatedModels);
     if (reorderedByQuota[0] !== rotatedModels[0]) {
-      log?.info?.("COMBO", `Quota auto-switch: ${reorderedByQuota[0]} has most remaining quota → tried first`);
+      log?.info?.("COMBO", `Quota auto-switch: ${getComboEntryModel(reorderedByQuota[0])} has most remaining quota → tried first`);
     }
     rotatedModels = reorderedByQuota;
   }
-  
+
   let lastError = null;
   let earliestRetryAfter = null;
   let lastStatus = null;
-  // Track every model we've tried (combo entries + family-fallback expansions)
-  // so the family lookup doesn't suggest something we already burned.
   const triedModels = new Set();
 
   for (let i = 0; i < rotatedModels.length; i++) {
-    let modelStr = rotatedModels[i];
+    const entry = rotatedModels[i];
+    let modelStr = getComboEntryModel(entry);
     let familyFallbackAttempts = 0;
-    const MAX_FAMILY_FALLBACK = 3; // bounded per combo entry
+    const MAX_FAMILY_FALLBACK = 3;
 
-    // Inner loop: same combo entry may swap to a sibling model if upstream
-    // says the model itself is unavailable (deleted, not enabled, etc.).
-    // We stay on this combo "slot" until either (a) we get a non-model-unavailable
-    // result, or (b) we've exhausted MAX_FAMILY_FALLBACK siblings.
     while (true) {
       log.info("COMBO", `Trying model ${i + 1}/${rotatedModels.length}: ${modelStr}${familyFallbackAttempts > 0 ? ` (family-fallback ${familyFallbackAttempts})` : ""}`);
       triedModels.add(modelStr);
 
     try {
-      const result = await handleSingleModel(body, modelStr);
+      const attemptBody = applyComboEntryReasoning(body, entry);
+      const result = await handleSingleModel(attemptBody, modelStr);
       
       // Success (2xx) - return response
       if (result.ok) {
@@ -586,7 +571,7 @@ function collectPanel(calls, { minPanel, stragglerGraceMs, panelHardTimeoutMs })
  * Degrades gracefully: 0 panel answers -> 503, exactly 1 -> return it directly.
  */
 export async function handleFusionChat({ body, models, handleSingleModel, log, comboName, judgeModel, tuning }) {
-  const panel = Array.isArray(models) ? models.filter(Boolean) : [];
+  const panel = Array.isArray(models) ? models.filter((e) => getComboEntryModel(e)) : [];
   if (panel.length === 0) {
     return new Response(
       JSON.stringify({ error: { message: "Fusion combo has no models" } }),
@@ -595,30 +580,27 @@ export async function handleFusionChat({ body, models, handleSingleModel, log, c
   }
 
   if (panel.length === 1) {
-    return handleSingleModel(body, panel[0]);
+    return handleSingleModel(applyComboEntryReasoning(body, panel[0]), getComboEntryModel(panel[0]));
   }
 
   const cfg = { ...FUSION_DEFAULTS, ...(tuning || {}) };
   const minPanel = Math.min(Math.max(2, cfg.minPanel), panel.length);
-  const judge = judgeModel && judgeModel.trim() ? judgeModel.trim() : panel[0];
-  log.info("FUSION", `Combo "${comboName}" | panel=${panel.length} [${panel.join(", ")}] | judge=${judge} | quorum=${minPanel}`);
+  const judgeEntry = judgeModel && judgeModel.trim() ? null : panel[0];
+  const judge = judgeModel && judgeModel.trim() ? judgeModel.trim() : getComboEntryModel(panel[0]);
+  log.info("FUSION", `Combo "${comboName}" | panel=${panel.length} [${panel.map((e) => getComboEntryModel(e)).join(", ")}] | judge=${judge} | quorum=${minPanel}`);
 
-  // 1. Fan out to the panel in parallel: non-streaming, tools stripped.
-  // upstream 6d30ce6d — the panel runs non-streaming, so stream_options must go too
-  // or providers like DeepSeek reject it ("stream_options should be set along with
-  // stream = true").
   const { tools, tool_choice, stream_options, ...rest } = body;
   const panelBody = { ...rest, stream: false };
   const t0 = Date.now();
-  const calls = panel.map((m) => withTimeout(handleSingleModel(panelBody, m), cfg.panelHardTimeoutMs));
+  const calls = panel.map((entry) => withTimeout(handleSingleModel(applyComboEntryReasoning(panelBody, entry), getComboEntryModel(entry)), cfg.panelHardTimeoutMs));
   const settled = await collectPanel(calls, { ...cfg, minPanel });
   log.info("FUSION", `fan-out collected in ${Date.now() - t0}ms`);
 
-  // 2. Collect successful answers.
   const answers = [];
   for (let i = 0; i < settled.length; i++) {
     const res = settled[i];
-    const model = panel[i];
+    const entry = panel[i];
+    const model = getComboEntryModel(entry);
     if (!res) { log.warn("FUSION", `Panel ${model} dropped (straggler/timeout)`); continue; }
     if (res.__timeout) { log.warn("FUSION", `Panel ${model} timed out`); continue; }
     if (res.__error) { log.warn("FUSION", `Panel ${model} threw`, { error: res.__error?.message || String(res.__error) }); continue; }
@@ -627,7 +609,7 @@ export async function handleFusionChat({ body, models, handleSingleModel, log, c
       const json = await res.clone().json();
       const text = extractPanelText(json);
       if (text) {
-        answers.push({ model, text });
+        answers.push({ model, entry, text });
         log.info("FUSION", `Panel ${model} ok (${text.length} chars)`);
       } else {
         log.warn("FUSION", `Panel ${model} returned empty content`);
@@ -647,11 +629,11 @@ export async function handleFusionChat({ body, models, handleSingleModel, log, c
   }
   if (answers.length === 1) {
     log.info("FUSION", `Only ${answers[0].model} succeeded — answering directly (no fusion)`);
-    return handleSingleModel(body, answers[0].model);
+    return handleSingleModel(applyComboEntryReasoning(body, answers[0].entry), answers[0].model);
   }
 
   // 4. Judge analyzes + writes one final answer (streams to client if requested).
   const judgeBody = appendUserTurn(body, buildJudgePrompt(answers));
   log.info("FUSION", `Judging ${answers.length} answers with ${judge}`);
-  return handleSingleModel(judgeBody, judge);
+  return handleSingleModel(judgeEntry ? applyComboEntryReasoning(judgeBody, judgeEntry) : judgeBody, judge);
 }

--- a/open-sse/services/comboEntry.js
+++ b/open-sse/services/comboEntry.js
@@ -1,0 +1,103 @@
+export const COMBO_REASONING_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+const VALID_REASONING = new Set(COMBO_REASONING_LEVELS);
+
+export function isValidComboReasoning(value) {
+  if (value === undefined || value === null || value === "") return true;
+  return VALID_REASONING.has(String(value).trim().toLowerCase());
+}
+
+export function getComboEntryModel(entry) {
+  if (typeof entry === "string") return entry.trim();
+  if (!entry || typeof entry !== "object") return "";
+  if (typeof entry.model === "string" && entry.model.trim()) {
+    const model = entry.model.trim();
+    if (typeof entry.provider === "string" && entry.provider.trim() && !model.includes("/")) {
+      return `${entry.provider.trim()}/${model}`;
+    }
+    return model;
+  }
+  if (typeof entry.id === "string" && entry.id.trim()) return entry.id.trim();
+  if (typeof entry.name === "string" && entry.name.trim()) {
+    if (typeof entry.provider === "string" && entry.provider.trim() && !entry.name.includes("/")) {
+      return `${entry.provider.trim()}/${entry.name.trim()}`;
+    }
+    return entry.name.trim();
+  }
+  return "";
+}
+
+export function getComboEntryReasoning(entry) {
+  if (!entry || typeof entry !== "object") return null;
+  const raw = entry.reasoning ?? entry.reasoning_effort;
+  if (raw === undefined || raw === null) return null;
+  const value = String(raw).trim().toLowerCase();
+  if (!value || value === "auto") return null;
+  return value;
+}
+
+export function normalizeComboEntry(entry) {
+  if (typeof entry === "string") {
+    const model = entry.trim();
+    return model || null;
+  }
+  if (!entry || typeof entry !== "object") return null;
+  const model = getComboEntryModel(entry);
+  if (!model) return null;
+  const reasoning = getComboEntryReasoning(entry);
+  if (!reasoning) return model;
+  if (!isValidComboReasoning(reasoning)) return null;
+  return { model, reasoning };
+}
+
+export function normalizeComboEntries(entries) {
+  if (!Array.isArray(entries)) return [];
+  return entries.map(normalizeComboEntry).filter(Boolean);
+}
+
+export function hasValidComboEntries(entries) {
+  return Array.isArray(entries) && entries.every((entry) => normalizeComboEntry(entry) !== null);
+}
+
+const THINKING_BUDGETS = {
+  minimal: 2048,
+  low: 4096,
+  medium: 8192,
+  high: 16384,
+  xhigh: 32768,
+  max: 65536,
+};
+
+export function applyComboEntryReasoning(body, entry) {
+  const reasoning = getComboEntryReasoning(entry);
+  if (!reasoning) return body;
+  const next = { ...(body || {}) };
+  if (reasoning === "none") {
+    delete next.reasoning_effort;
+    if (next.reasoning && typeof next.reasoning === "object") {
+      const nextReasoning = { ...next.reasoning };
+      delete nextReasoning.effort;
+      if (Object.keys(nextReasoning).length > 0) next.reasoning = nextReasoning;
+      else delete next.reasoning;
+    }
+    delete next.thinking;
+    if (next.output_config && typeof next.output_config === "object") {
+      const outputConfig = { ...next.output_config };
+      delete outputConfig.effort;
+      if (Object.keys(outputConfig).length > 0) next.output_config = outputConfig;
+      else delete next.output_config;
+    }
+    return next;
+  }
+  if (next.thinking && typeof next.thinking === "object") {
+    next.thinking = { type: "enabled", budget_tokens: THINKING_BUDGETS[reasoning] || next.thinking.budget_tokens || 8192 };
+  } else if (next.output_config && typeof next.output_config === "object") {
+    next.output_config = { ...next.output_config, effort: reasoning };
+  } else {
+    next.reasoning_effort = reasoning;
+    if (next.reasoning && typeof next.reasoning === "object") {
+      next.reasoning = { ...next.reasoning, effort: reasoning };
+    }
+  }
+  return next;
+}

--- a/open-sse/services/compact.js
+++ b/open-sse/services/compact.js
@@ -1,71 +1,7 @@
 /**
  * Shared combo (model combo) handling with fallback support
+ * Legacy alias — delegates to combo.js so string[] and {model,reasoning}
+ * entries behave identically everywhere.
  */
-
-/**
- * Get combo models from combos data
- * @param {string} modelStr - Model string to check
- * @param {Array|Object} combosData - Array of combos or object with combos
- * @returns {string[]|null} Array of models or null if not a combo
- */
-export function getComboModelsFromData(modelStr, combosData) {
-  // Don't check if it's in provider/model format
-  if (modelStr.includes("/")) return null;
-  
-  // Handle both array and object formats
-  const combos = Array.isArray(combosData) ? combosData : (combosData?.combos || []);
-  
-  const combo = combos.find(c => c.name === modelStr);
-  if (combo && combo.models && combo.models.length > 0) {
-    return combo.models;
-  }
-  return null;
-}
-
-/**
- * Handle combo chat with fallback
- * @param {Object} options
- * @param {Object} options.body - Request body
- * @param {string[]} options.models - Array of model strings to try
- * @param {Function} options.handleSingleModel - Function to handle single model: (body, modelStr) => Promise<Response>
- * @param {Object} options.log - Logger object
- * @returns {Promise<Response>}
- */
-export async function handleComboChat({ body, models, handleSingleModel, log }) {
-  let lastError = null;
-
-  for (let i = 0; i < models.length; i++) {
-    const modelStr = models[i];
-    log.info("COMBO", `Trying model ${i + 1}/${models.length}: ${modelStr}`);
-
-    let result;
-    try {
-      result = await handleSingleModel(body, modelStr);
-    } catch (e) {
-      lastError = `${modelStr}: ${e.message}`;
-      log.warn("COMBO", `Model threw exception, trying next`, { model: modelStr, error: e.message });
-      continue;
-    }
-
-    // Success or client error - return response
-    if (result.ok || result.status < 500) {
-      return result;
-    }
-
-    // 5xx error - try next model
-    lastError = `${modelStr}: ${result.statusText || result.status}`;
-    log.warn("COMBO", `Model failed, trying next`, { model: modelStr, status: result.status });
-  }
-
-  log.warn("COMBO", "All models failed");
-  
-  // Return 503 with last error
-  return new Response(
-    JSON.stringify({ error: lastError || "All combo models unavailable" }),
-    { 
-      status: 503, 
-      headers: { "Content-Type": "application/json" }
-    }
-  );
-}
+export { getComboModelsFromData, handleComboChat } from "./combo.js";
 

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -12,6 +12,31 @@ import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/sha
 // Validate combo name: only a-z, A-Z, 0-9, -, _
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
 
+const COMBO_REASONING_OPTIONS = ["auto", "none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+function entryModel(entry) {
+  if (typeof entry === "string") return entry;
+  if (!entry || typeof entry !== "object") return "";
+  return entry.model || entry.id || entry.name || "";
+}
+
+function entryReasoning(entry) {
+  if (!entry || typeof entry !== "object") return "auto";
+  return entry.reasoning || entry.reasoning_effort || "auto";
+}
+
+function withEntryReasoning(entry, reasoning) {
+  const model = entryModel(entry);
+  if (!reasoning || reasoning === "auto") return model;
+  return { model, reasoning };
+}
+
+function entryLabel(entry) {
+  const model = entryModel(entry);
+  const reasoning = entryReasoning(entry);
+  return reasoning && reasoning !== "auto" ? `${model} (${reasoning})` : model;
+}
+
 // 0.5.126 (upstream 8e59093d, adapted) — Capacity adapter: global fallback pools of
 // models per input-modality capability. A request needing a capability the target
 // model/combo lacks switches to the first enabled model here instead of dropping the
@@ -303,9 +328,9 @@ function ComboCard({ combo, activeProviders = [], copied, onCopy, onEdit, onDele
               {combo.models.length === 0 ? (
                 <span className="text-xs text-text-muted italic">No models</span>
               ) : (
-                combo.models.slice(0, 3).map((model, index) => (
+                combo.models.slice(0, 3).map((entry, index) => (
                   <code key={index} className="max-w-full truncate rounded bg-black/5 px-1.5 py-0.5 font-mono text-[10px] text-text-muted dark:bg-white/5 sm:max-w-[220px]">
-                    {model}
+                    {entryLabel(entry)}
                   </code>
                 ))
               )}
@@ -323,7 +348,7 @@ function ComboCard({ combo, activeProviders = [], copied, onCopy, onEdit, onDele
                   title="Pick the model that fuses panel answers"
                 >
                   <span className="material-symbols-outlined text-[13px]">gavel</span>
-                  <span className="truncate">{judge || `Auto — ${combo.models[0] || "first model"}`}</span>
+                  <span className="truncate">{judge || `Auto — ${entryLabel(combo.models[0]) || "first model"}`}</span>
                 </button>
                 {judge && (
                   <button
@@ -538,7 +563,7 @@ function CapacityAdapterCap({ cap, entry, onChange, activeProviders }) {
   );
 }
 
-function ModelItem({ id, index, model, isFirst, isLast, onEdit, onMoveUp, onMoveDown, onRemove }) {
+function ModelItem({ id, index, model, reasoning, isFirst, isLast, onEdit, onReasoning, onMoveUp, onMoveDown, onRemove }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useSortable({ id });
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -604,6 +629,14 @@ function ModelItem({ id, index, model, isFirst, isLast, onEdit, onMoveUp, onMove
         </div>
       )}
 
+      {/* Per-entry reasoning effort (auto = client value) */}
+      <select value={reasoning} onChange={(e) => onReasoning(e.target.value)} title="Reasoning effort for this entry (auto = client value)"
+        className="shrink-0 rounded border border-black/10 bg-white px-1 py-0.5 font-mono text-[11px] text-text-main outline-none dark:border-white/10 dark:bg-black/20">
+        {COMBO_REASONING_OPTIONS.map((level) => (
+          <option key={level} value={level}>{level}</option>
+        ))}
+      </select>
+
       {/* Priority arrows */}
       <div className="flex shrink-0 items-center gap-0.5">
         <button
@@ -651,7 +684,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindF
   );
 
   // Use stable index-based IDs so duplicates and similar names are handled correctly
-  const modelItems = models.map((model, i) => ({ uid: `item-${i}`, model }));
+  const modelItems = models.map((entry, i) => ({ uid: `item-${i}`, model: entryModel(entry), reasoning: entryReasoning(entry) }));
 
   const handleDragEnd = (event) => {
     const { active, over } = event;
@@ -700,13 +733,30 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindF
   };
 
   const handleAddModel = (model) => {
-    if (!models.includes(model.value)) {
-      setModels([...models, model.value]);
-    }
+    const value = model?.value || model;
+    if (!value) return;
+    if (models.some((m) => entryModel(m) === value)) return;
+    setModels([...models, value]);
   };
 
   const handleDeselectModel = (model) => {
-    setModels(models.filter((m) => m !== model.value));
+    const value = model?.value || model;
+    setModels(models.filter((m) => entryModel(m) !== value));
+  };
+
+  const handleSetReasoning = (index, reasoning) => {
+    const updated = [...models];
+    updated[index] = withEntryReasoning(updated[index], reasoning);
+    setModels(updated);
+  };
+
+  const handleEditModel = (index, newVal) => {
+    const trimmed = String(newVal || "").trim();
+    if (!trimmed) return;
+    const updated = [...models];
+    const reasoning = entryReasoning(updated[index]);
+    updated[index] = reasoning && reasoning !== "auto" ? { model: trimmed, reasoning } : trimmed;
+    setModels(updated);
   };
 
   const handleRemoveModel = (index) => {
@@ -771,19 +821,17 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindF
             <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} modifiers={[restrictToVerticalAxis, restrictToParentElement]}>
               <SortableContext items={modelItems.map((m) => m.uid)} strategy={verticalListSortingStrategy}>
                 <div className="flex max-h-[55vh] min-w-0 flex-col gap-1 overflow-y-auto sm:max-h-[350px]">
-                  {modelItems.map(({ uid, model }, index) => (
+                  {modelItems.map(({ uid, model, reasoning }, index) => (
                     <ModelItem
                       key={uid}
                       id={uid}
                       index={index}
                       model={model}
+                      reasoning={reasoning}
                       isFirst={index === 0}
                       isLast={index === modelItems.length - 1}
-                      onEdit={(newVal) => {
-                        const updated = [...models];
-                        updated[index] = newVal;
-                        setModels(updated);
-                      }}
+                      onEdit={(newVal) => handleEditModel(index, newVal)}
+                      onReasoning={(r) => handleSetReasoning(index, r)}
                       onMoveUp={() => handleMoveUp(index)}
                       onMoveDown={() => handleMoveDown(index)}
                       onRemove={() => handleRemoveModel(index)}
@@ -831,7 +879,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindF
         modelAliases={modelAliases}
         title="Add Model to Combo"
         kindFilter={kindFilter}
-        addedModelValues={models}
+        addedModelValues={models.map((m) => entryModel(m))}
         closeOnSelect={false}
       />
     </>

--- a/src/app/(dashboard)/dashboard/media-providers/[kind]/page.js
+++ b/src/app/(dashboard)/dashboard/media-providers/[kind]/page.js
@@ -108,10 +108,11 @@ function ComboList({ combos }) {
               <code className="text-sm font-mono font-medium flex-1 truncate">{combo.name}</code>
               <div className="flex flex-wrap items-center gap-1 sm:shrink-0">
                 {combo.models.slice(0, 6).map((entry, i) => {
-                  const pid = typeof entry === "string" ? entry.split("/")[0] : "";
+                  const modelStr = typeof entry === "string" ? entry : (entry?.model || entry?.id || entry?.name || "");
+                  const pid = modelStr.split("/")[0] || "";
                   const p = AI_PROVIDERS[pid];
                   return (
-                    <div key={`${entry}-${i}`} title={p?.name || entry} className="size-5 rounded flex items-center justify-center" style={{ backgroundColor: `${(p?.color ?? "#888")}15` }}>
+                    <div key={`${modelStr}-${i}`} title={p?.name || modelStr} className="size-5 rounded flex items-center justify-center" style={{ backgroundColor: `${(p?.color ?? "#888")}15` }}>
                       <ProviderIcon
                         src={`/providers/${pid}.png`}
                         alt={p?.name || pid}

--- a/src/app/(dashboard)/dashboard/media-providers/combo/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/media-providers/combo/[id]/page.js
@@ -8,11 +8,20 @@ import ProviderIcon from "@/shared/components/ProviderIcon";
 import { AI_PROVIDERS, MEDIA_PROVIDER_KINDS } from "@/shared/constants/providers";
 
 // Parse "providerId/model" or just "providerId" → { providerId, model }
+// Entry may be a legacy string or { model, reasoning } object.
+function entryModelString(entry) {
+  if (typeof entry === "string") return entry;
+  if (!entry || typeof entry !== "object") return "";
+  return entry.model || entry.id || entry.name || "";
+}
+
 function parseModelEntry(entry) {
-  if (typeof entry !== "string") return { providerId: "", model: "" };
-  const idx = entry.indexOf("/");
-  if (idx < 0) return { providerId: entry, model: "" };
-  return { providerId: entry.slice(0, idx), model: entry.slice(idx + 1) };
+  const str = entryModelString(entry);
+  const reasoning = (!entry || typeof entry !== "object") ? "" : (entry.reasoning || entry.reasoning_effort || "");
+  if (typeof str !== "string" || !str) return { providerId: "", model: "", reasoning: "" };
+  const idx = str.indexOf("/");
+  if (idx < 0) return { providerId: str, model: "", reasoning };
+  return { providerId: str.slice(0, idx), model: str.slice(idx + 1), reasoning };
 }
 
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
@@ -120,7 +129,8 @@ export default function ComboDetailPage() {
 
   const handleAddModel = async (model) => {
     const value = model?.value || model;
-    if (!value || providers.includes(value)) return;
+    if (!value) return;
+    if (providers.some((p) => entryModelString(p) === value)) return;
     const next = [...providers, value];
     setProviders(next);
     await saveCombo({ models: next });
@@ -128,8 +138,9 @@ export default function ComboDetailPage() {
 
   const handleDeselectModel = async (model) => {
     const value = model?.value || model;
-    if (!value || !providers.includes(value)) return;
-    const next = providers.filter((p) => p !== value);
+    if (!value) return;
+    if (!providers.some((p) => entryModelString(p) === value)) return;
+    const next = providers.filter((p) => entryModelString(p) !== value);
     setProviders(next);
     await saveCombo({ models: next });
   };
@@ -294,10 +305,11 @@ export default function ComboDetailPage() {
         ) : (
           <div className="flex flex-col gap-2">
             {providers.map((entry, idx) => {
-              const { providerId, model } = parseModelEntry(entry);
+              const { providerId, model, reasoning } = parseModelEntry(entry);
+              const modelStr = entryModelString(entry);
               const p = AI_PROVIDERS[providerId];
               return (
-                <div key={`${entry}-${idx}`} className="flex items-center gap-3 p-2 rounded-lg bg-black/[0.02] dark:bg-white/[0.02]">
+                <div key={`${modelStr}-${idx}`} className="flex items-center gap-3 p-2 rounded-lg bg-black/[0.02] dark:bg-white/[0.02]">
                   <span className="text-xs text-text-muted w-5 text-center">{idx + 1}</span>
                   <ProviderIcon
                     src={`/providers/${providerId}.png`}
@@ -309,7 +321,7 @@ export default function ComboDetailPage() {
                   />
                   <div className="min-w-0 flex-1">
                     <div className="text-sm font-medium truncate">{p?.name || providerId}</div>
-                    {model && <code className="text-[10px] text-text-muted font-mono truncate block">{model}</code>}
+                    {model && <code className="text-[10px] text-text-muted font-mono truncate block">{model}{reasoning ? ` (${reasoning})` : ""}</code>}
                   </div>
                   <div className="flex items-center gap-0.5">
                     <button onClick={() => handleMove(idx, -1)} disabled={idx === 0} className={`p-1 rounded ${idx === 0 ? "text-text-muted/20" : "text-text-muted hover:text-primary hover:bg-black/5"}`} title="Move up">
@@ -402,7 +414,7 @@ export default function ComboDetailPage() {
         modelAliases={modelAliases}
         title={`Add ${kindLabel} Model`}
         kindFilter={combo.kind}
-        addedModelValues={providers}
+        addedModelValues={providers.map((p) => entryModelString(p))}
         closeOnSelect={false}
       />
     </div>

--- a/src/app/(dashboard)/dashboard/media-providers/web/page.js
+++ b/src/app/(dashboard)/dashboard/media-providers/web/page.js
@@ -78,10 +78,11 @@ function ComboList({ combos }) {
               {/* Provider icons preview */}
               <div className="flex flex-wrap items-center gap-1 sm:shrink-0">
                 {combo.models.slice(0, 6).map((entry, i) => {
-                  const pid = typeof entry === "string" ? entry.split("/")[0] : "";
+                  const modelStr = typeof entry === "string" ? entry : (entry?.model || entry?.id || entry?.name || "");
+                  const pid = modelStr.split("/")[0] || "";
                   const p = AI_PROVIDERS[pid];
                   return (
-                    <div key={`${entry}-${i}`} title={p?.name || entry} className="size-5 rounded flex items-center justify-center" style={{ backgroundColor: `${(p?.color ?? "#888")}15` }}>
+                    <div key={`${modelStr}-${i}`} title={p?.name || modelStr} className="size-5 rounded flex items-center justify-center" style={{ backgroundColor: `${(p?.color ?? "#888")}15` }}>
                       <ProviderIcon
                         src={`/providers/${pid}.png`}
                         alt={p?.name || pid}

--- a/src/app/api/combos/[id]/route.js
+++ b/src/app/api/combos/[id]/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getComboById, updateCombo, deleteCombo, getComboByName } from "@/lib/localDb";
 import { resetComboRotation } from "open-sse/services/combo.js";
+import { normalizeComboEntries } from "open-sse/services/comboEntry.js";
 
 // Validate combo name: only a-z, A-Z, 0-9, -, _
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
@@ -43,6 +44,16 @@ export async function PUT(request, { params }) {
     
     // Capture previous name to invalidate rotation state on rename
     const prev = await getComboById(id);
+    if (body.models !== undefined) {
+      if (!Array.isArray(body.models)) {
+        return NextResponse.json({ error: "Models must be an array" }, { status: 400 });
+      }
+      const normalized = normalizeComboEntries(body.models);
+      if (normalized.length !== body.models.length) {
+        return NextResponse.json({ error: "Each combo entry must be a \"provider/model\" string or { model, reasoning } with a valid effort" }, { status: 400 });
+      }
+      body = { ...body, models: normalized };
+    }
     const combo = await updateCombo(id, body);
     
     if (!combo) {

--- a/src/app/api/combos/route.js
+++ b/src/app/api/combos/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCombos, createCombo, getComboByName } from "@/lib/localDb";
+import { normalizeComboEntries } from "open-sse/services/comboEntry.js";
 
 export const dynamic = "force-dynamic";
 
@@ -22,7 +23,6 @@ export async function POST(request) {
   try {
     const body = await request.json();
     const { name, models, kind } = body;
-
     if (!name) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
     }
@@ -38,7 +38,13 @@ export async function POST(request) {
       return NextResponse.json({ error: "Combo name already exists" }, { status: 400 });
     }
 
-    const combo = await createCombo({ name, models: models || [], kind: kind || null });
+    const rawModels = Array.isArray(models) ? models : [];
+    const normalized = normalizeComboEntries(rawModels);
+    if (rawModels.length > 0 && normalized.length !== rawModels.length) {
+      return NextResponse.json({ error: "Each combo entry must be a \"provider/model\" string or { model, reasoning } with a valid effort" }, { status: 400 });
+    }
+
+    const combo = await createCombo({ name, models: normalized, kind: kind || null });
 
     return NextResponse.json(combo, { status: 201 });
   } catch (error) {

--- a/src/shared/components/ComboFormModal.js
+++ b/src/shared/components/ComboFormModal.js
@@ -8,8 +8,27 @@ import ModelSelectModal from "./ModelSelectModal";
 
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
 
+const COMBO_REASONING_OPTIONS = ["auto", "none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+function entryModel(entry) {
+  if (typeof entry === "string") return entry;
+  if (!entry || typeof entry !== "object") return "";
+  return entry.model || entry.id || entry.name || "";
+}
+
+function entryReasoning(entry) {
+  if (!entry || typeof entry !== "object") return "auto";
+  return entry.reasoning || entry.reasoning_effort || "auto";
+}
+
+function withEntryReasoning(entry, reasoning) {
+  const model = entryModel(entry);
+  if (!reasoning || reasoning === "auto") return model;
+  return { model, reasoning };
+}
+
 // Inline editable model item
-function ModelItem({ index, model, isFirst, isLast, onEdit, onMoveUp, onMoveDown, onRemove }) {
+function ModelItem({ index, model, reasoning, isFirst, isLast, onEdit, onReasoning, onMoveUp, onMoveDown, onRemove }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(model);
   const commit = () => {
@@ -32,6 +51,12 @@ function ModelItem({ index, model, isFirst, isLast, onEdit, onMoveUp, onMoveDown
         <div className="min-w-0 flex-1 cursor-text truncate rounded px-1.5 py-0.5 font-mono text-xs text-text-main hover:bg-black/5 dark:hover:bg-white/5"
           onClick={() => setEditing(true)} title="Click to edit">{model}</div>
       )}
+      <select value={reasoning} onChange={(e) => onReasoning(e.target.value)} title="Reasoning effort for this entry (auto = client value)"
+        className="shrink-0 rounded border border-black/10 bg-white px-1 py-0.5 font-mono text-[11px] text-text-main outline-none dark:border-white/10 dark:bg-black/20">
+        {COMBO_REASONING_OPTIONS.map((level) => (
+          <option key={level} value={level}>{level}</option>
+        ))}
+      </select>
       <div className="flex shrink-0 items-center gap-0.5">
         <button onClick={onMoveUp} disabled={isFirst}
           className={`p-0.5 rounded ${isFirst ? "text-text-muted/20 cursor-not-allowed" : "text-text-muted hover:text-primary hover:bg-black/5 dark:hover:bg-white/5"}`} title="Move up">
@@ -84,12 +109,29 @@ export default function ComboFormModal({ isOpen, combo, onClose, onSave, activeP
   };
 
   const handleAddModel = (model) => {
-    if (!models.includes(model.value)) setModels([...models, model.value]);
+    const value = model?.value || model;
+    if (!value) return;
+    if (models.some((m) => entryModel(m) === value)) return;
+    setModels([...models, value]);
   };
   const handleDeselectModel = (model) => {
-    setModels(models.filter((m) => m !== model.value));
+    const value = model?.value || model;
+    setModels(models.filter((m) => entryModel(m) !== value));
   };
   const handleRemoveModel = (i) => setModels(models.filter((_, idx) => idx !== i));
+  const handleSetReasoning = (i, reasoning) => {
+    const a = [...models];
+    a[i] = withEntryReasoning(a[i], reasoning);
+    setModels(a);
+  };
+  const handleEditModel = (i, v) => {
+    const trimmed = String(v || "").trim();
+    if (!trimmed) return;
+    const a = [...models];
+    const reasoning = entryReasoning(a[i]);
+    a[i] = reasoning && reasoning !== "auto" ? { model: trimmed, reasoning } : trimmed;
+    setModels(a);
+  };
   const handleMoveUp = (i) => {
     if (i === 0) return;
     const a = [...models]; [a[i - 1], a[i]] = [a[i], a[i - 1]]; setModels(a);
@@ -140,10 +182,11 @@ export default function ComboFormModal({ isOpen, combo, onClose, onSave, activeP
               </div>
             ) : (
               <div className="flex max-h-[55vh] min-w-0 flex-col gap-1 overflow-y-auto sm:max-h-[350px]">
-                {models.map((model, index) => (
-                  <ModelItem key={index} index={index} model={model}
+                {models.map((entry, index) => (
+                  <ModelItem key={index} index={index} model={entryModel(entry)} reasoning={entryReasoning(entry)}
                     isFirst={index === 0} isLast={index === models.length - 1}
-                    onEdit={(v) => { const a = [...models]; a[index] = v; setModels(a); }}
+                    onEdit={(v) => handleEditModel(index, v)}
+                    onReasoning={(r) => handleSetReasoning(index, r)}
                     onMoveUp={() => handleMoveUp(index)}
                     onMoveDown={() => handleMoveDown(index)}
                     onRemove={() => handleRemoveModel(index)} />
@@ -170,7 +213,7 @@ export default function ComboFormModal({ isOpen, combo, onClose, onSave, activeP
         onSelect={handleAddModel} onDeselect={handleDeselectModel}
         activeProviders={activeProviders} modelAliases={modelAliases}
         title="Add Model to Combo" kindFilter={kindFilter}
-        addedModelValues={models} closeOnSelect={false} />
+        addedModelValues={models.map((m) => entryModel(m))} closeOnSelect={false} />
     </>
   );
 }

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -14,7 +14,7 @@ import { stripModelContextMarker } from "open-sse/utils/modelMarkers.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
 import { getRetiredModelError } from "open-sse/config/retiredModels.js";
 import { getEffectiveFallbackStrategy } from "open-sse/config/providerStrategy.js";
-import { handleComboChat, handleFusionChat, detectRequiredCapabilities } from "open-sse/services/combo.js";
+import { handleComboChat, handleFusionChat, detectRequiredCapabilities, getComboEntryModel } from "open-sse/services/combo.js";
 import { augmentModelsWithCapacityAdapter, withCapacityAdapterStripping, getActiveAdapterStrategy } from "open-sse/services/capacityAdapter.js";
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
 import { getTransform as getPxpipeTransform, configureModelBases as configurePxpipeModels } from "@/lib/pxpipe/loader.js";
@@ -176,7 +176,8 @@ export async function handleChat(request, clientRawRequest = null) {
     const comboStrategy = comboSpecificStrategy || settings.comboStrategy || "fallback";
     // Append capacity-adapter models only when NO combo member can satisfy the request.
     const augmentedModels = augmentModelsWithCapacityAdapter(comboModels, requiredCapabilities, settings);
-    const adapterAdded = augmentedModels.filter((m) => !comboModels.includes(m));
+    const comboModelSet = new Set(comboModels.map((m) => getComboEntryModel(m)));
+    const adapterAdded = augmentedModels.filter((m) => !comboModelSet.has(getComboEntryModel(m)));
 
     if (comboStrategy === "fusion") {
       log.info("CHAT", `Combo "${modelStr}" with ${comboModels.length} models (strategy: fusion)`);

--- a/tests/unit/combo-reasoning-effort.test.js
+++ b/tests/unit/combo-reasoning-effort.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  normalizeComboEntry,
+  normalizeComboEntries,
+  getComboEntryModel,
+  getComboEntryReasoning,
+  applyComboEntryReasoning,
+  handleComboChat,
+  handleFusionChat,
+  resetComboRotation,
+} from "../../open-sse/services/combo.js";
+
+const log = { info: () => {}, warn: () => {}, error: () => {} };
+const ok = (obj) =>
+  new Response(JSON.stringify(obj), { status: 200, headers: { "Content-Type": "application/json" } });
+const fail = (status, message) =>
+  new Response(JSON.stringify({ error: { message } }), { status, headers: { "Content-Type": "application/json" } });
+
+describe("combo per-entry reasoning effort", () => {
+  beforeEach(() => {
+    resetComboRotation();
+  });
+
+  it("keeps legacy string entries untouched", () => {
+    expect(normalizeComboEntry("  openai/gpt-4o  ")).toBe("openai/gpt-4o");
+    expect(normalizeComboEntries(["a/m1", "a/m2"])).toEqual(["a/m1", "a/m2"]);
+    expect(getComboEntryModel("a/m1")).toBe("a/m1");
+    expect(getComboEntryReasoning("a/m1")).toBeNull();
+  });
+
+  it("normalizes { model, reasoning } and accepts reasoning_effort alias", () => {
+    expect(normalizeComboEntry({ model: "a/m1", reasoning: "high" })).toEqual({ model: "a/m1", reasoning: "high" });
+    expect(normalizeComboEntry({ model: "a/m1", reasoning_effort: "LOW" })).toEqual({ model: "a/m1", reasoning: "low" });
+    expect(normalizeComboEntry({ model: "a/m1", reasoning: "auto" })).toBe("a/m1");
+    expect(normalizeComboEntry({ model: "a/m1", reasoning: "bogus" })).toBeNull();
+    expect(normalizeComboEntry({ model: "  " })).toBeNull();
+  });
+
+  it("applyComboEntryReasoning overrides client effort per attempt", () => {
+    const base = { model: "combo", reasoning_effort: "low" };
+    const out = applyComboEntryReasoning(base, { model: "a/m1", reasoning: "high" });
+    expect(out.reasoning_effort).toBe("high");
+    expect(base.reasoning_effort).toBe("low");
+  });
+
+  it("auto entries return the original body untouched", () => {
+    const base = { model: "combo", reasoning_effort: "low" };
+    expect(applyComboEntryReasoning(base, "a/m1")).toBe(base);
+    expect(applyComboEntryReasoning(base, { model: "a/m1", reasoning: "auto" })).toEqual(base);
+  });
+
+  it("none strips reasoning fields", () => {
+    const base = {
+      model: "combo",
+      reasoning_effort: "high",
+      reasoning: { effort: "high" },
+      thinking: { type: "enabled", budget_tokens: 16384 },
+    };
+    const out = applyComboEntryReasoning(base, { model: "a/m1", reasoning: "none" });
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.reasoning).toBeUndefined();
+    expect(out.thinking).toBeUndefined();
+  });
+
+  it("fallback applies each entry effort only on its own attempt", async () => {
+    const seen = [];
+    const handleSingleModel = async (b, m) => {
+      seen.push({ model: m, effort: b.reasoning_effort });
+      if (m === "a/m1") return fail(500, "boom");
+      return ok({ choices: [{ message: { content: "fine" } }] });
+    };
+    const res = await handleComboChat({
+      body: { model: "combo", messages: [] },
+      models: [
+        { model: "a/m1", reasoning: "high" },
+        { model: "a/m2", reasoning: "low" },
+      ],
+      handleSingleModel,
+      log,
+      comboName: "test-combo-effort",
+      comboStrategy: "fallback",
+      autoSwitch: false,
+    });
+    expect(res.ok).toBe(true);
+    expect(seen).toEqual([
+      { model: "a/m1", effort: "high" },
+      { model: "a/m2", effort: "low" },
+    ]);
+  });
+
+  it("fusion fans out panel efforts and judge inherits first entry", async () => {
+    const calls = [];
+    const handleSingleModel = async (b, m) => {
+      calls.push({ model: m, effort: b.reasoning_effort, stream: b.stream });
+      if (calls.length <= 2) {
+        return ok({ choices: [{ message: { content: `answer from ${m}` } }] });
+      }
+      return ok({ choices: [{ message: { content: "final" } }] });
+    };
+    const res = await handleFusionChat({
+      body: { model: "combo", messages: [{ role: "user", content: "hi" }] },
+      models: [
+        { model: "a/m1", reasoning: "high" },
+        { model: "a/m2", reasoning: "low" },
+      ],
+      handleSingleModel,
+      log,
+      comboName: "test-fusion-effort",
+    });
+    expect(res.ok).toBe(true);
+    expect(calls[0]).toMatchObject({ model: "a/m1", effort: "high", stream: false });
+    expect(calls[1]).toMatchObject({ model: "a/m2", effort: "low", stream: false });
+    expect(calls[2].model).toBe("a/m1");
+    expect(calls[2].effort).toBe("high");
+  });
+});


### PR DESCRIPTION
Combo entries accept { model, reasoning } alongside plain provider/model strings, keeping legacy string[] combos working.

- Per-attempt effort via applyComboEntryReasoning (open-sse/services/comboEntry.js); overrides client reasoning_effort, auto preserves it, none strips reasoning fields.
- Covers fallback, round-robin, fusion panel + judge inheritance, capacity adapter, API normalization, dashboard editors, media-providers lists, CLI prompts.
- Adds tests/unit/combo-reasoning-effort.test.js.

Base: a77ddc5 (main, v0.5.159). Branch: ruanbarroso/krouter feat/combo-reasoning-effort.